### PR TITLE
Make PR number clickable by making it a link with the PR URL

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,7 @@
 ---
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
-change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-template: "- $TITLE @$AUTHOR ([#$NUMBER]($URL))"
 sort-direction: ascending
 
 categories:


### PR DESCRIPTION
This makes the PR number clickable outside of the GitHub UI (like inside the add-on panel and update entities in Home Assistant)

<https://github.com/release-drafter/release-drafter#change-template-variables>